### PR TITLE
ensure we return the right error code

### DIFF
--- a/src/services/mail.js
+++ b/src/services/mail.js
@@ -40,7 +40,8 @@ export class MailService {
         error = errors[response.statusCode];
 
         if (error) {
-          return reject(new Error('Error sending email to Sendgrid', body));
+          /* eslint new-cap: 0 */
+          return reject(new error('Error sending email to Sendgrid', body));
         }
 
         resolve({ sent: true });


### PR DESCRIPTION
### Summary

I think this got changed when we introduced the eslint rules and auto-fixed this repo. This ensures that errors returned by sendgrid retain the correct error code.